### PR TITLE
Fix : fastify example

### DIFF
--- a/examples/fastify/bin/start.ts
+++ b/examples/fastify/bin/start.ts
@@ -1,8 +1,7 @@
 import { hot } from 'hot-hook'
-import { join } from 'node:path'
 
 await hot.init({
-  projectRoot: join(import.meta.dirname, '..'),
+  root: import.meta.filename,
   reload: ['src/index.ts'],
 })
 

--- a/examples/fastify/src/index.ts
+++ b/examples/fastify/src/index.ts
@@ -16,7 +16,7 @@ fastify.get('/', async (request, reply) => {
 
 const start = async () => {
   try {
-    throw new Error('foo')
+    await fastify.listen({ port: 3000 })
   } catch (err) {
     fastify.log.error(err)
     process.exit(1)


### PR DESCRIPTION
Fix the fastify example :
- Use the new `root` option
- Remove the throw statement and properly start the Fastify server 