### PR TITLE
feat: add hot-hook/register entrypoint loader

### DIFF
--- a/.changeset/few-hotels-grab.md
+++ b/.changeset/few-hotels-grab.md
@@ -1,0 +1,30 @@
+---
+"hot-hook": patch
+---
+
+This PR adds a new way of configuring hot-hook. This allows you to configure hot-hook without having to modify your codebase. 
+
+We introduce a new `hot-hook/register` entrypoint that can be used with Node.JS's `--import` flag. By using this method, the Hot Hook hook will be loaded at application startup without you needing to use `hot.init` in your codebase. It can be used as follows:
+
+```bash
+node --import=hot-hook/register ./src/index.js
+```
+
+Be careful if you also use a loader to transpile to TS (`ts-node` or `tsx`), hot-hook must be placed in the second position, after the TS loader :
+
+```bash
+node --import=tsx --import=hot-hook/register ./src/index.ts
+```
+
+To configure boundaries and other files, you'll need to use your application's `package.json` file, in the `hot-hook` key. For example: 
+
+```jsonc
+// package.json
+{
+  "hot-hook": {
+    "boundaries": [
+      "./src/controllers/**/*.tsx"
+    ]
+  }
+}
+```

--- a/README.md
+++ b/README.md
@@ -17,7 +17,36 @@ The library is designed to be very light and simple. It doesn't perform any dark
 pnpm add hot-hook
 ```
 
-Once installed, you need to add the following code as early as possible in your NodeJS application.
+### Initialization
+
+You have two ways to initialize Hot Hook in your application.
+
+### Using `--import` flag
+
+You can use the `--import` flag to load the Hot Hook hook at application startup without needing to use `hot.init` in your codebase. If you are using a loader to transpile to TS (`ts-node` or `tsx`), Hot Hook must be placed in the second position, after the TS loader otherwise it won't work.
+
+```bash
+node --import=tsx --import=hot-hook/register ./src/index.ts
+```
+
+To configure boundaries and other files, you'll need to use your application's `package.json` file, in the `hot-hook` key. For example: 
+
+```json
+// package.json
+{
+  "hot-hook": {
+    "boundaries": [
+      "./src/controllers/**/*.tsx"
+    ]
+  }
+}
+```
+
+Or you can still use the `import.meta.hot?.boundary` attribute in your code to specify which files should be hot reloadable.
+
+### Using `hot.init`
+
+You need to add the following code as early as possible in your NodeJS application.
 
 ```ts
 import { hot } from 'hot-hook'
@@ -196,6 +225,9 @@ It's quite simple. However, we ship a process manager with Hot Hook. See the doc
 ```ts
 await import('./users_controller.js', import.meta.hot?.boundary)
 ```
+
+> [!TIP]
+> One important thing to note is, ONLY dynamic imports can be hot reloadable. Static imports will not be hot reloadable so don't declare them as boundaries. Read more about this [here](#esm-cache-busting).
 
 By importing a module this way, you are essentially creating a kind of boundary. This module and all the modules imported by it will be hot reloadable.
 

--- a/examples/fastify/bin/start.ts
+++ b/examples/fastify/bin/start.ts
@@ -1,8 +1,0 @@
-import { hot } from 'hot-hook'
-
-await hot.init({
-  root: import.meta.filename,
-  boundaries: ['../src/services/**.ts'],
-})
-
-await import('../src/index.js')

--- a/examples/fastify/package.json
+++ b/examples/fastify/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev:tsnode": "hot-runner --node-args=\"--import=./tsnode.esm.js\" bin/start.ts",
-    "dev:tsx": "hot-runner --node-args=\"--import=tsx\" bin/start.ts"
+    "dev:tsnode": "hot-runner --node-args=--import=./tsnode.esm.js --node-args=--import=hot-hook/register src/index.ts",
+    "dev:tsx": "hot-runner --node-args=--import=tsx --node-args=--import=hot-hook/register src/index.ts"
   },
   "devDependencies": {
     "@hot-hook/runner": "workspace:*",
@@ -16,5 +16,10 @@
   },
   "dependencies": {
     "fastify": "^4.26.2"
+  },
+  "hot-hook": {
+    "boundaries": [
+      "./services/**/*.ts"
+    ]
   }
 }

--- a/examples/fastify/src/index.ts
+++ b/examples/fastify/src/index.ts
@@ -1,16 +1,9 @@
 import Fastify from 'fastify'
 
-const fastify = Fastify({
-  logger: {
-    transport: {
-      target: 'pino-pretty',
-      options: { translateTime: 'HH:MM:ss Z', ignore: 'pid,hostname' },
-    },
-  },
-})
+const fastify = Fastify({ logger: { transport: { target: 'pino-pretty' } } })
 
-fastify.get('/', async (request, reply) => {
-  const { PostsService } = await import('./services/posts_service.js', { with: { hot: 'true' } })
+fastify.get('/', async (_, __) => {
+  const { PostsService } = await import('./services/posts_service.js')
   return new PostsService().getPosts()
 })
 
@@ -18,7 +11,7 @@ fastify.get('/', async (request, reply) => {
  * This route is totally optional and can be used to visualize
  * your dependency graph in a browser.
  */
-fastify.get('/dump-viewer', async (request, reply) => {
+fastify.get('/dump-viewer', async (_, reply) => {
   const { dumpViewer } = await import('@hot-hook/dump-viewer')
 
   reply.header('Content-Type', 'text/html; charset=utf-8')

--- a/examples/fastify/src/services/posts_service.ts
+++ b/examples/fastify/src/services/posts_service.ts
@@ -1,4 +1,4 @@
-import { uppercasePostTitles } from '../helpers/posts'
+import { uppercasePostTitles } from '../helpers/posts.js'
 
 export class PostsService {
   /**

--- a/examples/hono/bin/start.ts
+++ b/examples/hono/bin/start.ts
@@ -1,4 +1,0 @@
-import { hot } from 'hot-hook'
-
-await hot.init({ root: import.meta.filename })
-await import('../src/index.js')

--- a/examples/hono/package.json
+++ b/examples/hono/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev:tsnode": "hot-runner --node-args=\"--import=./tsnode.esm.js\" bin/start.ts",
+    "dev:tsnode": "hot-runner --node-args=--import=./tsnode.esm.js --node-args=--import=hot-hook/register src/index.tsx",
     "dev:tsx": "hot-runner --node-args=\"--import=tsx\" bin/start.ts"
   },
   "devDependencies": {
@@ -14,5 +14,11 @@
   "dependencies": {
     "@hono/node-server": "^1.9.0",
     "hono": "^4.1.4"
+  },
+  "hot-hook": {
+    "root": "./bin/server.ts",
+    "boundaries": [
+      "./views/**/*.tsx"
+    ]
   }
 }

--- a/examples/hono/package.json
+++ b/examples/hono/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "dev:tsnode": "hot-runner --node-args=--import=./tsnode.esm.js --node-args=--import=hot-hook/register src/index.tsx",
-    "dev:tsx": "hot-runner --node-args=\"--import=tsx\" bin/start.ts"
+    "dev:tsx": "hot-runner --node-args=--import=tsx --node-args=--import=hot-hook/register src/index.tsx"
   },
   "devDependencies": {
     "hot-hook": "workspace:*",
@@ -16,7 +16,6 @@
     "hono": "^4.1.4"
   },
   "hot-hook": {
-    "root": "./bin/server.ts",
     "boundaries": [
       "./views/**/*.tsx"
     ]

--- a/examples/hono/src/index.tsx
+++ b/examples/hono/src/index.tsx
@@ -27,7 +27,7 @@ console.log('Ready to serve requests')
 const app = new Hono()
 
 app.get('/', async (c) => {
-  const { Home } = await import('./views/home.js', { with: { hot: 'true' } })
+  const { Home } = await import('./views/home.js')
   return c.html(<Home />)
 })
 

--- a/examples/node_http_basic/package.json
+++ b/examples/node_http_basic/package.json
@@ -3,10 +3,15 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev:tsnode": "hot-runner --node-args=\"--import=./tsnode.esm.js\" bin/start.ts"
+    "dev:tsnode": "hot-runner --node-args=--import=./tsnode.esm.js --node-args=--import=hot-hook/register src/index.ts"
   },
   "devDependencies": {
     "hot-hook": "workspace:*",
     "@hot-hook/runner": "workspace:*"
+  },
+  "hot-hook": {
+    "boundaries": [
+      "./app.ts"
+    ]
   }
 }

--- a/examples/node_http_basic/src/index.ts
+++ b/examples/node_http_basic/src/index.ts
@@ -1,10 +1,10 @@
 import * as http from 'node:http'
 
 const server = http.createServer(async (request, response) => {
-  const app = await import('./app.js', import.meta.hot?.boundary)
+  const app = await import('./app.js')
   app.default(request, response)
 })
 
-server.listen(8080)
+server.listen(3000)
 
-console.log('Server running at http://localhost:8080/')
+console.log('Server running at http://localhost:3000/')

--- a/packages/hot_hook/package.json
+++ b/packages/hot_hook/package.json
@@ -11,7 +11,7 @@
   "exports": {
     ".": "./build/src/hot.js",
     "./loader": "./build/src/loader.js",
-    "./runner": "./build/src/runner.js",
+    "./register": "./build/src/register.js",
     "./import-meta": {
       "types": "./import-meta.d.ts"
     }
@@ -33,7 +33,8 @@
   "dependencies": {
     "chokidar": "^3.6.0",
     "fast-glob": "^3.3.2",
-    "picomatch": "^4.0.2"
+    "picomatch": "^4.0.2",
+    "read-package-up": "^11.0.0"
   },
   "author": "Julien Ripouteau <julien@ripouteau.com>",
   "license": "MIT",

--- a/packages/hot_hook/src/dependency_tree.ts
+++ b/packages/hot_hook/src/dependency_tree.ts
@@ -39,12 +39,16 @@ export default class DependencyTree {
   #tree!: FileNode
   #pathMap: Map<string, FileNode> = new Map()
 
-  constructor(options: { root: string }) {
+  constructor(options: { root?: string }) {
+    if (options.root) this.addRoot(options.root)
+  }
+
+  addRoot(path: string) {
     this.#tree = {
       version: 0,
       parents: null,
       reloadable: false,
-      path: options.root,
+      path: path,
       dependents: new Set(),
       dependencies: new Set(),
     }

--- a/packages/hot_hook/src/register.ts
+++ b/packages/hot_hook/src/register.ts
@@ -13,5 +13,5 @@ const hotHookConfig = packageJson['hot-hook']
 await hot.init({
   root: hotHookConfig?.root ? resolve(packageJsonPath, packageJson['hot-hook'].root) : undefined,
   boundaries: packageJson['hot-hook']?.boundaries,
-  ignore: packageJson['hot-hook']?.ignore,
+  ignore: ['**/node_modules/**'].concat(packageJson['hot-hook']?.ignore || []),
 })

--- a/packages/hot_hook/src/register.ts
+++ b/packages/hot_hook/src/register.ts
@@ -1,0 +1,17 @@
+import { resolve } from 'node:path'
+import { hot } from './hot.js'
+import { readPackageUp } from 'read-package-up'
+
+const pkgJson = await readPackageUp()
+if (!pkgJson) {
+  throw new Error('Could not find package.json')
+}
+
+const { packageJson, path: packageJsonPath } = pkgJson
+const hotHookConfig = packageJson['hot-hook']
+
+await hot.init({
+  root: hotHookConfig?.root ? resolve(packageJsonPath, packageJson['hot-hook'].root) : undefined,
+  boundaries: packageJson['hot-hook']?.boundaries,
+  ignore: packageJson['hot-hook']?.ignore,
+})

--- a/packages/hot_hook/src/types.ts
+++ b/packages/hot_hook/src/types.ts
@@ -21,7 +21,7 @@ export interface InitOptions {
   /**
    * Path to the root file of the application.
    */
-  root: string
+  root?: string
 
   /**
    * Files that will create an HMR boundary. This is equivalent of importing

--- a/packages/hot_hook/tests/loader.spec.ts
+++ b/packages/hot_hook/tests/loader.spec.ts
@@ -142,8 +142,6 @@ test.group('Loader', () => {
        if (import.meta.hot) {
         process.send({ type: 'ok' })
        }
-       console.log(import.meta.hot)
-       console.log("Hello")
     `
     )
     await fs.create(

--- a/packages/hot_hook/tests/register.spec.ts
+++ b/packages/hot_hook/tests/register.spec.ts
@@ -1,0 +1,131 @@
+import { join } from 'node:path'
+import { pEvent } from 'p-event'
+import supertest from 'supertest'
+import { test } from '@japa/runner'
+import { setTimeout } from 'node:timers/promises'
+
+import { createHandlerFile, fakeInstall, runProcess } from './helpers.js'
+
+test.group('Register', () => {
+  test('Works fine with', async ({ fs }) => {
+    await fakeInstall(fs.basePath)
+
+    await fs.createJson('package.json', { type: 'module' })
+    await fs.create(
+      'server.js',
+      `import * as http from 'http'
+       import { join } from 'node:path'
+
+       const server = http.createServer(async (request, response) => {
+         const app = await import('./app.js', import.meta.hot?.boundary)
+         await app.default(request, response)
+       })
+
+       server.listen(3333, () => console.log('Server is running'))`
+    )
+
+    await createHandlerFile({ path: 'app.js', response: 'Hello World!' })
+
+    const server = runProcess('server.js', {
+      cwd: fs.basePath,
+      env: { NODE_DEBUG: 'hot-hook' },
+      nodeOptions: ['--import=hot-hook/register'],
+    })
+
+    await server.waitForOutput('Server is running')
+
+    await supertest('http://localhost:3333').get('/').expect(200).expect('Hello World!')
+
+    await setTimeout(100)
+    await createHandlerFile({ path: 'app.js', response: 'Hello World! Updated' })
+    await supertest('http://localhost:3333').get('/').expect(200).expect('Hello World! Updated')
+
+    await setTimeout(100)
+    await createHandlerFile({ path: 'app.js', response: 'Hello World! Updated new' })
+    await supertest('http://localhost:3333').get('/').expect(200).expect('Hello World! Updated new')
+  })
+
+  test('send full reload message', async ({ fs, assert }) => {
+    await fakeInstall(fs.basePath)
+
+    await fs.createJson('package.json', { type: 'module' })
+    await fs.create(
+      'server.js',
+      `import * as http from 'http'
+       import { join } from 'node:path'
+
+       const server = http.createServer(async (request, response) => {
+         const app = await import('./app.js')
+         await app.default(request, response)
+       })
+
+       server.listen(3333, () => console.log('Server is running'))`
+    )
+
+    await createHandlerFile({ path: 'app.js', response: 'Hello World!' })
+
+    const server = runProcess('server.js', {
+      cwd: fs.basePath,
+      env: { NODE_DEBUG: 'hot-hook' },
+      nodeOptions: ['--import=hot-hook/register'],
+    })
+
+    await server.waitForOutput('Server is running')
+
+    await supertest('http://localhost:3333').get('/').expect(200).expect('Hello World!')
+    await setTimeout(100)
+
+    await createHandlerFile({ path: 'app.js', response: 'Hello World! Updated' })
+    const result = await pEvent(
+      server.child,
+      'message',
+      (message: any) =>
+        message?.type === 'hot-hook:full-reload' && message.path === join(fs.basePath, 'app.js')
+    )
+    assert.isDefined(result)
+  })
+
+  test('Can define hardcoded boundaries from package json', async ({ fs }) => {
+    await fakeInstall(fs.basePath)
+
+    await fs.createJson('package.json', {
+      'type': 'module',
+      'hot-hook': {
+        boundaries: ['./app.js'],
+      },
+    })
+    await fs.create(
+      'server.js',
+      `import * as http from 'http'
+       import { join } from 'node:path'
+
+       const server = http.createServer(async (request, response) => {
+         const app = await import('./app.js')
+         await app.default(request, response)
+       })
+
+       server.listen(3333, () => console.log('Server is running'))
+      `
+    )
+
+    await createHandlerFile({ path: 'app.js', response: 'Hello World!' })
+
+    const server = runProcess('server.js', {
+      cwd: fs.basePath,
+      env: { NODE_DEBUG: 'hot-hook' },
+      nodeOptions: ['--import=hot-hook/register'],
+    })
+
+    await server.waitForOutput('Server is running')
+
+    await supertest('http://localhost:3333').get('/').expect(200).expect('Hello World!')
+
+    await setTimeout(100)
+    await createHandlerFile({ path: 'app.js', response: 'Hello World! Updated' })
+    await supertest('http://localhost:3333').get('/').expect(200).expect('Hello World! Updated')
+
+    await setTimeout(100)
+    await createHandlerFile({ path: 'app.js', response: 'Hello World! Updated new' })
+    await supertest('http://localhost:3333').get('/').expect(200).expect('Hello World! Updated new')
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,6 +176,9 @@ importers:
       picomatch:
         specifier: ^4.0.2
         version: 4.0.2
+      read-package-up:
+        specifier: ^11.0.0
+        version: 11.0.0
     devDependencies:
       '@types/picomatch':
         specifier: ^2.3.3
@@ -311,7 +314,6 @@ packages:
     dependencies:
       '@babel/highlight': 7.24.2
       picocolors: 1.0.0
-    dev: true
 
   /@babel/compat-data@7.24.4:
     resolution: {integrity: sha512-vg8Gih2MLK+kOkHJp4gBEIkyaIi00jgWot2D9QOmmfLC8jINSOzmCLta6Bvz/JSBCqnegV0L80jhxkol5GWNfQ==}
@@ -488,7 +490,6 @@ packages:
   /@babel/helper-validator-identifier@7.22.20:
     resolution: {integrity: sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==}
     engines: {node: '>=6.9.0'}
-    dev: true
 
   /@babel/helper-validator-option@7.23.5:
     resolution: {integrity: sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==}
@@ -514,7 +515,6 @@ packages:
       chalk: 2.4.2
       js-tokens: 4.0.0
       picocolors: 1.0.0
-    dev: true
 
   /@babel/parser@7.24.4:
     resolution: {integrity: sha512-zTvEBcghmeBma9QIGunWevvBAp4/Qu9Bdq+2k0Ot4fVMD6v3dsC9WOcRSKk7tRRyBM/53yKMJko9xOatGQAwSg==}
@@ -2097,7 +2097,6 @@ packages:
 
   /@types/normalize-package-data@2.4.4:
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
-    dev: true
 
   /@types/picomatch@2.3.3:
     resolution: {integrity: sha512-Yll76ZHikRFCyz/pffKGjrCwe/le2CDwOP5F210KQo27kpRE46U2rDnzikNlVn6/ezH3Mhn46bJMTfeVTtcYMg==}
@@ -2582,7 +2581,6 @@ packages:
     engines: {node: '>=4'}
     dependencies:
       color-convert: 1.9.3
-    dev: true
 
   /ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
@@ -2931,7 +2929,6 @@ packages:
       ansi-styles: 3.2.1
       escape-string-regexp: 1.0.5
       supports-color: 5.5.0
-    dev: true
 
   /chalk@3.0.0:
     resolution: {integrity: sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==}
@@ -3060,7 +3057,6 @@ packages:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
     dependencies:
       color-name: 1.1.3
-    dev: true
 
   /color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -3071,7 +3067,6 @@ packages:
 
   /color-name@1.1.3:
     resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
-    dev: true
 
   /color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
@@ -3634,7 +3629,6 @@ packages:
   /escape-string-regexp@1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
     engines: {node: '>=0.8.0'}
-    dev: true
 
   /escape-string-regexp@2.0.0:
     resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
@@ -4016,6 +4010,11 @@ packages:
       safe-regex2: 2.0.0
     dev: false
 
+  /find-up-simple@1.0.0:
+    resolution: {integrity: sha512-q7Us7kcjj2VMePAa02hDAF6d+MzsdsAWEwYyOpwUtlerRBkOEPBCRZrAV4XfcSN8fHAgaD0hP7miwoay6DCprw==}
+    engines: {node: '>=18'}
+    dev: false
+
   /find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
@@ -4142,7 +4141,6 @@ packages:
 
   /function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
-    dev: true
 
   /function.prototype.name@1.1.6:
     resolution: {integrity: sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==}
@@ -4324,7 +4322,6 @@ packages:
   /has-flag@3.0.0:
     resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
     engines: {node: '>=4'}
-    dev: true
 
   /has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -4359,7 +4356,6 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       function-bind: 1.1.2
-    dev: true
 
   /he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
@@ -4390,6 +4386,13 @@ packages:
     dependencies:
       lru-cache: 6.0.0
     dev: true
+
+  /hosted-git-info@7.0.1:
+    resolution: {integrity: sha512-+K84LB1DYwMHoHSgaOY/Jfhw3ucPmSET5v98Ke/HdNSw4a0UktWzyW1mjhjpuxxTqOOsfWT/7iVshHmVZ4IpOA==}
+    engines: {node: ^16.14.0 || >=18.0.0}
+    dependencies:
+      lru-cache: 10.2.0
+    dev: false
 
   /html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
@@ -4445,6 +4448,11 @@ packages:
     resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
     engines: {node: '>=12'}
     dev: true
+
+  /index-to-position@0.1.2:
+    resolution: {integrity: sha512-MWDKS3AS1bGCHLBA2VLImJz42f7bJh8wQsTGCzI3j519/CASStoDONUBVz2I/VID0MpiX3SGSnbOD2xUalbE5g==}
+    engines: {node: '>=18'}
+    dev: false
 
   /inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
@@ -4523,7 +4531,6 @@ packages:
     resolution: {integrity: sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==}
     dependencies:
       hasown: 2.0.2
-    dev: true
 
   /is-data-view@1.0.1:
     resolution: {integrity: sha512-AHkaJrsUVW6wq6JS8y3JnM/GJF/9cf+k20+iDzlSaJrinEo5+7vRiteOSwBhHRiAyQATN1AmY4hwzxJKPmYf+w==}
@@ -4796,7 +4803,6 @@ packages:
 
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-    dev: true
 
   /js-yaml@3.14.1:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
@@ -5033,6 +5039,11 @@ packages:
     dependencies:
       get-func-name: 2.0.2
     dev: true
+
+  /lru-cache@10.2.0:
+    resolution: {integrity: sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==}
+    engines: {node: 14 || >=16.14}
+    dev: false
 
   /lru-cache@4.1.5:
     resolution: {integrity: sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==}
@@ -5296,6 +5307,16 @@ packages:
       validate-npm-package-license: 3.0.4
     dev: true
 
+  /normalize-package-data@6.0.0:
+    resolution: {integrity: sha512-UL7ELRVxYBHBgYEtZCXjxuD5vPxnmvMGq0jp/dGPKKrN7tfsBh2IY7TlJ15WWwdjRWD3RJbnsygUurTK3xkPkg==}
+    engines: {node: ^16.14.0 || >=18.0.0}
+    dependencies:
+      hosted-git-info: 7.0.1
+      is-core-module: 2.13.1
+      semver: 7.6.0
+      validate-npm-package-license: 3.0.4
+    dev: false
+
   /normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
@@ -5501,6 +5522,15 @@ packages:
       lines-and-columns: 1.2.4
     dev: true
 
+  /parse-json@8.1.0:
+    resolution: {integrity: sha512-rum1bPifK5SSar35Z6EKZuYPJx85pkNaFrxBK3mwdfSJ1/WKbYrjoW/zTPSjRRamfmVX1ACBIdFAO0VRErW/EA==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@babel/code-frame': 7.24.2
+      index-to-position: 0.1.2
+      type-fest: 4.15.0
+    dev: false
+
   /path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -5548,7 +5578,6 @@ packages:
 
   /picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
-    dev: true
 
   /picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
@@ -5777,6 +5806,15 @@ packages:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
     dev: true
 
+  /read-package-up@11.0.0:
+    resolution: {integrity: sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ==}
+    engines: {node: '>=18'}
+    dependencies:
+      find-up-simple: 1.0.0
+      read-pkg: 9.0.1
+      type-fest: 4.15.0
+    dev: false
+
   /read-pkg-up@7.0.1:
     resolution: {integrity: sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==}
     engines: {node: '>=8'}
@@ -5814,6 +5852,17 @@ packages:
       parse-json: 5.2.0
       type-fest: 1.4.0
     dev: true
+
+  /read-pkg@9.0.1:
+    resolution: {integrity: sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@types/normalize-package-data': 2.4.4
+      normalize-package-data: 6.0.0
+      parse-json: 8.1.0
+      type-fest: 4.15.0
+      unicorn-magic: 0.1.0
+    dev: false
 
   /read-yaml-file@1.1.0:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
@@ -6226,22 +6275,18 @@ packages:
     dependencies:
       spdx-expression-parse: 3.0.1
       spdx-license-ids: 3.0.17
-    dev: true
 
   /spdx-exceptions@2.5.0:
     resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
-    dev: true
 
   /spdx-expression-parse@3.0.1:
     resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
     dependencies:
       spdx-exceptions: 2.5.0
       spdx-license-ids: 3.0.17
-    dev: true
 
   /spdx-license-ids@3.0.17:
     resolution: {integrity: sha512-sh8PWc/ftMqAAdFiBu6Fy6JUOYjqDJBJvIhpfDMyHrr0Rbp5liZqd4TjtQ/RgfLjKFZb+LMx5hpml5qOWy0qvg==}
-    dev: true
 
   /split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
@@ -6401,7 +6446,6 @@ packages:
     engines: {node: '>=4'}
     dependencies:
       has-flag: 3.0.0
-    dev: true
 
   /supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -6636,6 +6680,11 @@ packages:
     engines: {node: '>=12.20'}
     dev: true
 
+  /type-fest@4.15.0:
+    resolution: {integrity: sha512-tB9lu0pQpX5KJq54g+oHOLumOx+pMep4RaM6liXh2PKmVRFF+/vAtUP0ZaJ0kOySfVNjF6doBWPHhBhISKdlIA==}
+    engines: {node: '>=16'}
+    dev: false
+
   /typed-array-buffer@1.0.2:
     resolution: {integrity: sha512-gEymJYKZtKXzzBzM4jqa9w6Q1Jjm7x2d+sh19AdsD4wqnMPDYyvwpsIc2Q/835kHuo3BEQ7CjelGhfTsoBb2MQ==}
     engines: {node: '>= 0.4'}
@@ -6711,6 +6760,11 @@ packages:
   /undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
     dev: true
+
+  /unicorn-magic@0.1.0:
+    resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
+    engines: {node: '>=18'}
+    dev: false
 
   /universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
@@ -6804,7 +6858,6 @@ packages:
     dependencies:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
-    dev: true
 
   /validator@13.11.0:
     resolution: {integrity: sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ==}


### PR DESCRIPTION
This PR adds a new way of configuring hot-hook. This allows you to configure hot-hook without having to modify your codebase. 

We introduce a new `hot-hook/register` entrypoint that can be used with Node.JS's `--import` flag. By using this method, the Hot Hook hook will be loaded at application startup without you needing to use `hot.init` in your codebase. It can be used as follows:

```bash
node --import=hot-hook/register ./src/index.js
```

Be careful if you also use a loader to transpile to TS (`ts-node` or `tsx`), hot-hook must be placed in the second position, after the TS loader :

```bash
node --import=tsx --import=hot-hook/register ./src/index.ts
```

To configure boundaries and other files, you'll need to use your application's `package.json` file, in the `hot-hook` key. For example: 

```jsonc
// package.json
{
  "hot-hook": {
    "boundaries": [
      "./src/controllers/**/*.tsx"
    ]
  }
}
```