### PR TITLE
Don´t register file instead of throwing if it is not hot-reloadable

### DIFF
--- a/packages/hot_hook/src/dynamic_import_checker.ts
+++ b/packages/hot_hook/src/dynamic_import_checker.ts
@@ -1,6 +1,6 @@
 import { readFile } from 'node:fs/promises'
 import { parseImports } from 'parse-imports'
-import { relative } from 'node:path'
+import { FileNotImportedDynamicallyException } from './file_not_imported_dynamically_exception.js'
 
 /**
  * This class is responsible for checking if a given specifier
@@ -34,9 +34,7 @@ export class DynamicImportChecker {
     this.cache.set(cacheKey, currentCache.set(specifier, isFileDynamicallyImportedFromParent))
 
     if (!isFileDynamicallyImportedFromParent) {
-      throw new Error(
-        `The import "${specifier}" is not imported dynamically from ${relative(this.projectRoot, parentPath)}.\nYou must use dynamic import to make it reloadable (HMR) with hot-hook.`
-      )
+      throw new FileNotImportedDynamicallyException(parentPath, specifier, this.projectRoot)
     }
 
     return isFileDynamicallyImportedFromParent

--- a/packages/hot_hook/src/file_not_imported_dynamically_exception.ts
+++ b/packages/hot_hook/src/file_not_imported_dynamically_exception.ts
@@ -1,0 +1,9 @@
+import { relative } from 'node:path'
+
+export class FileNotImportedDynamicallyException extends Error {
+  constructor(parentPath: string, specifier: string, projectRoot: string) {
+    super(
+      `The import "${specifier}" is not imported dynamically from ${relative(projectRoot, parentPath)}.\nYou must use dynamic import to make it reloadable (HMR) with hot-hook.`
+    )
+  }
+}


### PR DESCRIPTION
Hey there! 👋🏻

This PR introduces an update to how `hot-hook` handles files that aren't hot-reloadable. The goal is to improve the developer experience by ensuring `hot-hook` behaves more predictably when encountering these files.

The current implementation throws when detecting files that don't support hot-reloading if they are registered as boundaries. My approach changes this by simply skipping the registration of these files as reloadable, so instead of an error, we treat them as standard files that don’t participate in hot-reloading. This should help minimize confusion and interruptions during development.

I’m not entirely sure if my code fully addresses this behavior or how to best create a test for this specific use case. Could you help me with this, @Julien-R44?

One more thought: it might be helpful to log a warning message when `hot-hook` skips over a non-hot-reloadable file. This way, users understand why a cold-reload occurs after modifying specific files, which could save time and prevent potential confusion.