### PR TITLE
feat: consider missing import as dynamic

### DIFF
--- a/packages/hot_hook/src/dynamic_import_checker.ts
+++ b/packages/hot_hook/src/dynamic_import_checker.ts
@@ -7,6 +7,8 @@ import { parseImports } from 'parse-imports'
  * Otherwise we will throw an error since we cannot make the file reloadable
  *
  * We are caching the results to avoid reading the same file multiple times
+ *
+ * When no import is found for the given specifier we assume that it is imported using a dynamic specifier.
  */
 export class DynamicImportChecker {
   private cache: Map<string, Map<string, boolean>> = new Map()
@@ -20,9 +22,13 @@ export class DynamicImportChecker {
     const parentCode = await readFile(parentPath, 'utf-8')
     const imports = [...(await parseImports(parentCode))]
 
-    const isFileDynamicallyImportedFromParent = imports.some((importStatement) => {
-      return importStatement.isDynamicImport && importStatement.moduleSpecifier.value === specifier
+    const dynamicImports = imports.find((importStatement) => {
+      return importStatement.moduleSpecifier.value === specifier
     })
+
+    const isFileDynamicallyImportedFromParent = dynamicImports
+      ? dynamicImports.isDynamicImport
+      : true
 
     const currentCache = this.cache.get(cacheKey) ?? new Map()
     this.cache.set(cacheKey, currentCache.set(specifier, isFileDynamicallyImportedFromParent))


### PR DESCRIPTION
## Problem

As of today the `DynamicImportChecker` will look for an `import` with a specific specifier (the module specifier) meaning that imports using a dynamic value as specifier are not considered dynamic.

In the following example we are dynamically importing the modules present in the `./app/controllers` folder. But they are not marked as dynamically imported by hot-hook. 

```ts
  const pathes = await globby("./app/controllers", {
      absolute: true,
      expandDirectories: {
        extensions: ['ts', 'js', 'jsx'],
      },
    })

   for (const path of pathes) {
     await import(path)
   }
```

## Solution

We should consider the dependency graph as a source of truth meaning that if we do not find any import for a given specifier in the parent we can consider that it is imported with a dynamic value.